### PR TITLE
Format plain swap partitions

### DIFF
--- a/gentoo_autoinstaller_allfixes.sh
+++ b/gentoo_autoinstaller_allfixes.sh
@@ -273,6 +273,8 @@ if [[ "$SWAP_MODE" == "luks" ]]; then
   printf '%s' "$ROOT_PW_LUKS" | cryptsetup luksFormat --type luks2 --batch-mode --key-file - "$SWAP_PART"
   printf '%s' "$ROOT_PW_LUKS" | cryptsetup open --key-file - "$SWAP_PART" cryptswap
   mkswap -L swap /dev/mapper/cryptswap
+else
+  mkswap -L swap "$SWAP_PART"
 fi
 
 # ---------- mount target ----------


### PR DESCRIPTION
## Summary
- Format swap partition when using plain swap
- Ensure fstab and crypttab continue referencing the swap mapping

## Testing
- `bash -n gentoo_autoinstaller_allfixes.sh`
- `shellcheck gentoo_autoinstaller_allfixes.sh` (reports existing warnings)


------
https://chatgpt.com/codex/tasks/task_e_68980185fde8832780a334f4f2fdfba1